### PR TITLE
fix typo, producing a name error

### DIFF
--- a/PyTestStub/Generator.py
+++ b/PyTestStub/Generator.py
@@ -25,7 +25,7 @@ import os
 
 from PyTestStub import Templates
 
-def generateUnitTest(root, fileName, inlcudeInternal=False):
+def generateUnitTest(root, fileName, includeInternal=False):
 	"""
 	Generates a unit test, given a root directory and a subpath to a file.
 


### PR DESCRIPTION
Couldn't run the repo due to this error. Works fine after it's fixed.